### PR TITLE
fix: can not set customize group name when thing name is specified

### DIFF
--- a/greengrass-entrypoint.sh
+++ b/greengrass-entrypoint.sh
@@ -60,10 +60,11 @@ parse_options() {
 		if [ ${THING_NAME} != default_thing_name ]; then
 		    OPTIONS="${OPTIONS} --thing-name ${THING_NAME}"
 
-		    # If thing group name is specified, add optional argument
-		    if [ ${THING_GROUP_NAME} != default_thing_group_name ]; then
-		    	OPTIONS="${OPTIONS} --thing-group-name ${THING_GROUP_NAME}"
-			fi
+		    
+		fi
+		# If thing group name is specified, add optional argument
+		if [ ${THING_GROUP_NAME} != default_thing_group_name ]; then
+			OPTIONS="${OPTIONS} --thing-group-name ${THING_GROUP_NAME}"
 		fi
 	fi
 


### PR DESCRIPTION
**Issue #, if available:**

I can not set customize thing group name when thing name is specified

**Description of changes:**
change customize group name scope
**Why is this change necessary:**

**How was this change tested:**
Rebuild docker image and run it with '.env' that only thing group name is specified without thing name
**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the greengrass-entrypoint.sh

