### PR TITLE
Modify sudoers on every start

### DIFF
--- a/greengrass-entrypoint.sh
+++ b/greengrass-entrypoint.sh
@@ -100,11 +100,13 @@ parse_options() {
 	echo "Running Greengrass with the following options: ${OPTIONS}"
 }
 
+# Always modify /etc/sudoers
+modify_sudoers
+
 # If we have not already installed Greengrass
 if [ ! -d $GGC_ROOT_PATH/alts/current/distro ]; then
 	# Install Greengrass via the main installer, but do not start running
-	echo "Installing Greengrass for the first time..."
-	modify_sudoers
+	echo "Installing Greengrass for the first time..."	
 	parse_options
 	java ${OPTIONS}
 else


### PR DESCRIPTION
Fix for issue #10

**Issue #, if available:**
10

**Description of changes:**
Moved `modify_sudoers` function call so that it is executed at every start of the container

**Why is this change necessary:**
On restarts the `/etc/sudoers` file would be the original one not allowing Greengrass to operate correctly

**How was this change tested:**
By building the container and running it

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
