### PR TITLE
Add greengrass version label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,16 @@
 
 FROM amazonlinux:2
 
-# Author
-LABEL maintainer="AWS IoT Greengrass"
-
 # Replace the args to lock to a specific version
 ARG GREENGRASS_RELEASE_VERSION=2.1.0
 ARG GREENGRASS_ZIP_FILE=greengrass-${GREENGRASS_RELEASE_VERSION}.zip
 ARG GREENGRASS_RELEASE_URI=https://d2s8p88vqu9w66.cloudfront.net/releases/${GREENGRASS_ZIP_FILE}
 ARG GREENGRASS_ZIP_SHA256=${GREENGRASS_ZIP_FILE}.sha256
+
+# Author
+LABEL maintainer="AWS IoT Greengrass"
+# Greengrass Version
+LABEL greengrass-version=${GREENGRASS_RELEASE_VERSION}
 
 # Set up Greengrass v2 execution parameters
 # TINI_KILL_PROCESS_GROUP allows forwarding SIGTERM to all PIDs in the PID group so Greengrass can exit gracefully


### PR DESCRIPTION
**Issue #, if available:**


**Description of changes:**
add a version tag to know the greengrass version without needing to look inside the image filesystem.

**Why is this change necessary:**

**How was this change tested:**
`docker build`
`docker inspect` to verify the label shows the right version

```
"Labels": {
                "greengrass-version": "2.1.0",
                "maintainer": "AWS IoT Greengrass"
            }
```

**Checklist:**
- [ ] Updated the README if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
