### PR TITLE
Move modify sudoers to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,9 @@ RUN yum update -y && yum install -y python37 tar unzip wget sudo procps which &&
     chmod +x /greengrass-entrypoint.sh && \
     mkdir -p /opt/greengrassv2 $GGC_ROOT_PATH && unzip $GREENGRASS_ZIP_FILE -d /opt/greengrassv2 && rm $GREENGRASS_ZIP_FILE && rm $GREENGRASS_ZIP_SHA256
 
+# modify /etc/sudoers
+COPY "modify-sudoers.sh" /
+RUN chmod +x /modify-sudoers.sh
+RUN ./modify-sudoers.sh
+
 ENTRYPOINT ["/greengrass-entrypoint.sh"]

--- a/modify-sudoers.sh
+++ b/modify-sudoers.sh
@@ -14,11 +14,11 @@ ROOT_LINE_NUM=$(grep -n "^root" /etc/sudoers | cut -d : -f 1)
 if sudo sed -n "${ROOT_LINE_NUM}p" /etc/sudoers | grep -q "ALL=(ALL:ALL)" ; then
   echo "Root user is already configured to execute commands as other users."
   return 0
-  fi
+fi
 
 echo "Attempting to safely modify /etc/sudoers..."
 
-  # Take a backup of /etc/sudoers
+# Take a backup of /etc/sudoers
 sudo cp /etc/sudoers /tmp/sudoers.bak
 
 # Replace `ALL=(ALL)` with `ALL=(ALL:ALL)` to allow the root user to execute commands as other users

--- a/modify-sudoers.sh
+++ b/modify-sudoers.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# Allow the root user to execute commands as other users
+
+set -e
+
+# Grab the line number for the root user entry
+ROOT_LINE_NUM=$(grep -n "^root" /etc/sudoers | cut -d : -f 1)
+
+# Check if the root user is already configured to execute commands as other users
+if sudo sed -n "${ROOT_LINE_NUM}p" /etc/sudoers | grep -q "ALL=(ALL:ALL)" ; then
+  echo "Root user is already configured to execute commands as other users."
+  return 0
+  fi
+
+echo "Attempting to safely modify /etc/sudoers..."
+
+  # Take a backup of /etc/sudoers
+sudo cp /etc/sudoers /tmp/sudoers.bak
+
+# Replace `ALL=(ALL)` with `ALL=(ALL:ALL)` to allow the root user to execute commands as other users
+sudo sed -i "$ROOT_LINE_NUM s/ALL=(ALL)/ALL=(ALL:ALL)/" /tmp/sudoers.bak
+
+# Validate syntax of backup file
+sudo visudo -cf /tmp/sudoers.bak
+if [ $? -eq 0 ]; then
+  # Replace the sudoers file with the new only if syntax is correct.
+  sudo mv /tmp/sudoers.bak /etc/sudoers
+  echo "Successfully modified /etc/sudoers. Root user is now configured to execute commands as other users."
+else
+  echo "Error while trying to modify /etc/sudoers, please edit manually."
+  exit 1
+fi


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/aws-greengrass/aws-greengrass-docker/issues/10
Basing changes on this PR: https://github.com/aws-greengrass/aws-greengrass-docker/pull/11

**Description of changes:**
Moved `modify_sudoers` to Dockerfile so that changes to `/etc/sudoers` are persisted upon container restarts.

**Why is this change necessary:**
Changes to `/etc/sudoers` are not persisted when container restarts. This change addresses the issue. 

**How was this change tested:**
Build the container and run it by following reproduction steps listed here https://github.com/aws-greengrass/aws-greengrass-docker/issues/10 . Docker container was restarted with `docker run` as opposed to `docker start`. 
Verified that upon restart `/etc/sudoers`  contains  `root	ALL=(ALL:ALL) 	ALL `

**Any additional information or context required to review the change:**
This issue only occurs when user has mounted a host folder as /greengrass/v2 in the container. 

**Checklist:**
- [ ] Updated the README if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
