### PR TITLE
chore: bump to 2.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,9 @@ Greengrass v2.5.2 release notes: https://docs.aws.amazon.com/greengrass/v2/devel
 Greengrass in Docker release with Greengrass v2.5.3
 Includes bug fixes and improvements
 Greengrass v2.5.3 release notes:https://docs.aws.amazon.com/greengrass/v2/developerguide/greengrass-release-2022-01-06.html
+
+## v2.5.4
+
+Greengrass in Docker release with Greengrass v2.5.4
+Includes bug fixes and improvements
+Greengrass v2.5.4 release notes:https://docs.aws.amazon.com/greengrass/v2/developerguide/greengrass-release-2022-03-23.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM amazonlinux:2
 
 # Replace the args to lock to a specific version
-ARG GREENGRASS_RELEASE_VERSION=2.5.3
+ARG GREENGRASS_RELEASE_VERSION=2.5.4
 ARG GREENGRASS_ZIP_FILE=greengrass-${GREENGRASS_RELEASE_VERSION}.zip
 ARG GREENGRASS_RELEASE_URI=https://d2s8p88vqu9w66.cloudfront.net/releases/${GREENGRASS_ZIP_FILE}
 ARG GREENGRASS_ZIP_SHA256=greengrass.zip.sha256

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,4 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: aws-iot-greengrass
-    image: x86_64/aws-iot-greengrass:2.5.3
+    image: x86_64/aws-iot-greengrass:2.5.4

--- a/greengrass.zip.sha256
+++ b/greengrass.zip.sha256
@@ -1,1 +1,1 @@
-c7172422d76f108c9d5ec520fddaa2352e47a41bfb4d074ec7b52d35f5492b7a  greengrass-2.5.3.zip
+6098cd9bdbac0ce9ac372af8f257ec63ecba30484c2923e777f67c0ce8f851cc  greengrass-2.5.4.zip


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
new DockerFile 2.5.4 release
**Why is this change necessary:**
we need to bump the version
**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
