### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ sudo docker build -t "x86_64/aws-iot-greengrass:<GREENGRASS_VERSION>" ./
 **1.2.1** If you want to cross-build for a different platform, aarch64 for example.
 ```
 cd ~/Downloads/aws-greengrass-docker-<GREENGRASS_VERSION>
-sudo docker build --platform <platform> -t "aws-iot-greengrasss:<GREENGRASS_VERSION> ./"
+sudo docker build --platform <platform> -t "aws-iot-greengrasss:<GREENGRASS_VERSION>" ./
 ```
 
 `<platform>` can be `linux/aarch64` for example. See [Docker docs](https://docs.docker.com/build/building/multi-platform/#building-multi-platform-images) for more information.


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

Fix typo in building command.

**Why is this change necessary:**

invalid argument "aws-iot-greengrasss:2.5.3 ./" for "-t, --tag" flag: invalid reference format
See 'docker build --help'.

**How was this change tested:**

Successfully built.

**Any additional information or context required to review the change:**

N/A

**Checklist:**
- [√] Updated the README if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
