### PR TITLE
Bumped Nucleus to version 2.12.4.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-FROM amazonlinux:2
+FROM amazonlinux:2023
 
 # Replace the args to lock to a specific version
-ARG GREENGRASS_RELEASE_VERSION=2.10.3
+ARG GREENGRASS_RELEASE_VERSION=2.12.4
 ARG GREENGRASS_ZIP_FILE=greengrass-${GREENGRASS_RELEASE_VERSION}.zip
 ARG GREENGRASS_RELEASE_URI=https://d2s8p88vqu9w66.cloudfront.net/releases/${GREENGRASS_ZIP_FILE}
 
@@ -34,8 +34,8 @@ RUN env
 COPY "greengrass-entrypoint.sh" /
 
 # Install Greengrass v2 dependencies
-RUN yum update -y && yum install -y python37 tar unzip wget sudo procps which && \
-    amazon-linux-extras enable python3.8 && yum install -y python3.8 java-11-amazon-corretto-headless && \
+RUN yum update -y && \
+    yum install -y tar unzip wget sudo procps which shadow-utils python3 java-11-amazon-corretto-headless && \
     wget $GREENGRASS_RELEASE_URI && \
     rm -rf /var/cache/yum && \
     chmod +x /greengrass-entrypoint.sh && \


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
This version of Nucleus needed a more recent version of Amazon Linux, so also bumped it to version 2023.  
The 'python37' package does not exist anymore, the provided python version is 3.9.  
The 'shadow-utils' package is needed to provide the 'adduser' tool.

**Why is this change necessary:**
Nucleus version 2.12.x was needed to run TensorFlow Lite object detection version 2.11.1.

**How was this change tested:**
Deploying TensorFlow Lite object detection 2.11.1 (https://docs.aws.amazon.com/greengrass/v2/developerguide/tensorflow-lite-object-detection-component.html) and successfully getting the related MQTT messages.

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
