### PR TITLE
Added support for long-term security credentials provisioning.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ https://docs.aws.amazon.com/greengrass/v2/developerguide/interact-with-aws-servi
 	-e AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \  
 	-e AWS_SESSION_TOKEN=AQoDYXdzEJr1K...o5OytwEXAMPLE= \  
 	``` 
+
+	**2.1.3** **Use long-term security credentials from an IAM user:**
+	Use the following lines in the above command to provide the access key ID and secret access key from an IAM user that you assume for the container. For more information about how to retrieve these credentials, see [Use long-term credentials from an IAM user](https://docs.aws.amazon.com/greengrass/v2/developerguide/quick-installation.html#provide-installer-aws-credentials) in the Greengrass Developer Guide.
+
+	```
+	-e PROVISION=true \
+	-e AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE \
+	-e AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
+	```
   
 * If you would like to override any of the default configuration options or use your own config file to start Greengrass, specify those environment variables in the `environment` section as well. If you wish to use your own init config file, you must mount it to the directory you specify in the `INIT_CONFIG` environment variable, as well as mounting any extra files (e.g. custom certificates) you refer to in the init config file.  
 Please see [the installer documentation](https://docs.aws.amazon.com/greengrass/v2/developerguide/configure-installer.html ) for configuration options and behavior. 

--- a/greengrass-entrypoint.sh
+++ b/greengrass-entrypoint.sh
@@ -18,8 +18,8 @@ parse_options() {
 	# If provision is true
 	if [ ${PROVISION} = "true" ]; then
 
-		if [ ! -f "/root/.aws/credentials" ] && ([[ -z "${AWS_ACCESS_KEY_ID}" ]] || [[ -z "${AWS_SECRET_ACCESS_KEY}" ]] || [[ -z "${AWS_SESSION_TOKEN}" ]]); then
-			echo "Provision is set to true, but credentials not found, neither file exist at /root/.aws/credentials nor set in environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN) . Please attach credentials and retry."
+		if [ ! -f "/root/.aws/credentials" ] && ([[ -z "${AWS_ACCESS_KEY_ID}" ]] || [[ -z "${AWS_SECRET_ACCESS_KEY}" ]]); then
+			echo "Provision is set to true, but credentials not found, neither file exist at /root/.aws/credentials nor set in environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, [AWS_SESSION_TOKEN]) . Please attach credentials and retry."
 			exit 1
 		fi
 


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
The `greengrass-entrypoint.sh` script does not allow to provide only the provisioning access key ID and secret access key (this is required when using long-term credentials from an IAM user, see https://docs.aws.amazon.com/greengrass/v2/developerguide/quick-installation.html#provide-installer-aws-credentials).  
That's why the check for the AWS session token parameter has been removed from the `greengrass-entrypoint.sh` script, because it is not needed in such case.  
The README file has been updated accordingly.

**Why is this change necessary:**
To be able to configure the container with long-term credentials from an IAM user.

**How was this change tested:**
By seing the container connecting successfully to the AWS IoT web interface.

**Any additional information or context required to review the change:**

**Checklist:**
- [x] Updated the README if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
