### PR TITLE
ci: add ci and use latest version always

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: '*'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: wagoid/commitlint-github-action@v6
+      - name: Build image
+        run: docker build -t "aws-iot-greengrass:latest" ./
+      - name: Run image
+        run: docker run --init -e STARTUP=false aws-iot-greengrass:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM amazonlinux:2023
 
 # Replace the args to lock to a specific version
-ARG GREENGRASS_RELEASE_VERSION=2.12.4
+ARG GREENGRASS_RELEASE_VERSION=latest
 ARG GREENGRASS_ZIP_FILE=greengrass-${GREENGRASS_RELEASE_VERSION}.zip
 ARG GREENGRASS_RELEASE_URI=https://d2s8p88vqu9w66.cloudfront.net/releases/${GREENGRASS_ZIP_FILE}
 

--- a/greengrass-entrypoint.sh
+++ b/greengrass-entrypoint.sh
@@ -86,6 +86,11 @@ if [ ! -d $GGC_ROOT_PATH/alts/current/distro ]; then
 	echo "Installing Greengrass for the first time..."
 	parse_options
 	java ${OPTIONS}
+	if [ $? -ne 0 ]; then
+	  exit $?
+	elif [ ${STARTUP} = "false" ]; then
+	  exit 0
+  fi
 else
 	echo "Reusing existing Greengrass installation..."
 fi


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adds CI to verify that we can successfully build and execute Greengrass. No Greengrass functionality is validated except that it can successfully install itself.

Updates Dockerfile to always pull the latest version so that we don't need to update it. This also matches what our documentation says is supposed to happen.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
