### PR TITLE
fix: replace return in modify-sudoers

### DIFF
--- a/modify-sudoers.sh
+++ b/modify-sudoers.sh
@@ -13,7 +13,7 @@ ROOT_LINE_NUM=$(grep -n "^root" /etc/sudoers | cut -d : -f 1)
 # Check if the root user is already configured to execute commands as other users
 if sudo sed -n "${ROOT_LINE_NUM}p" /etc/sudoers | grep -q "ALL=(ALL:ALL)" ; then
   echo "Root user is already configured to execute commands as other users."
-  return 0
+  exit 0
 fi
 
 echo "Attempting to safely modify /etc/sudoers..."


### PR DESCRIPTION
**Issue #, if available:**
n/a

**Description of changes:**
Fixed a misplaced `return` instruction by a more appropriate `exit` instruction.

**Why is this change necessary:**
The `return` instruction can be used only in a function. The script crashes if the `return` instruction is being executed here because it is called out of a function body.

**How was this change tested:**
Running the script when the `sudoers` file was already updated was crashing the script. With the fix, the script now gracefully exits as expected.

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
