### PR TITLE
fix: add missing quotes to prevent unary operator error

### DIFF
--- a/greengrass-entrypoint.sh
+++ b/greengrass-entrypoint.sh
@@ -88,7 +88,7 @@ if [ ! -d $GGC_ROOT_PATH/alts/current/distro ]; then
 	java ${OPTIONS}
 	if [ $? -ne 0 ]; then
 	  exit $?
-	elif [ ${STARTUP} = "false" ]; then
+	elif [ "${STARTUP}" = "false" ]; then
 	  exit 0
   fi
 else


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/aws-greengrass/aws-greengrass-docker/issues/49

**Description of changes:**
Modified the bash script used for the `ENTRYPOINT`.

**Why is this change necessary:**
Without correcting the syntax of the bash script used for the `ENTRYPOINT` in the `Dockerfile`, then the following error is displayed in the output when trying to `docker run` the container:

```shell
Nucleus start set to false, exiting...
/greengrass-entrypoint.sh: line 91: [: =: unary operator expected
```

**How was this change tested:**
After making the correction, the `docker run` command executed as expected.

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
