### PR TITLE
Dockerfile to allow for Windows OS Docker Image Builds

### DIFF
--- a/Dockerfile4WindowsBuild
+++ b/Dockerfile4WindowsBuild
@@ -1,0 +1,54 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+# Update: This version of the Dockerfile allows the user to build the Docker Image on a Windows 10 (or later)
+
+FROM amazonlinux:2023
+# Use dos2unix to convert line-endings
+RUN yum install -y dos2unix
+
+# Replace the args to lock to a specific version
+ARG GREENGRASS_RELEASE_VERSION=latest
+ARG GREENGRASS_ZIP_FILE=greengrass-${GREENGRASS_RELEASE_VERSION}.zip
+ARG GREENGRASS_RELEASE_URI=https://d2s8p88vqu9w66.cloudfront.net/releases/${GREENGRASS_ZIP_FILE}
+
+# Author
+LABEL maintainer="AWS IoT Greengrass"
+# Greengrass Version
+LABEL greengrass-version=${GREENGRASS_RELEASE_VERSION}
+
+# Set up Greengrass v2 execution parameters
+# TINI_KILL_PROCESS_GROUP allows forwarding SIGTERM to all PIDs in the PID group so Greengrass can exit gracefully
+ENV TINI_KILL_PROCESS_GROUP=1 \ 
+    GGC_ROOT_PATH=/greengrass/v2 \
+    PROVISION=false \
+    AWS_REGION=us-east-1 \
+    THING_NAME=default_thing_name \
+    THING_GROUP_NAME=default_thing_group_name \
+    TES_ROLE_NAME=default_tes_role_name \
+    TES_ROLE_ALIAS_NAME=default_tes_role_alias_name \
+    COMPONENT_DEFAULT_USER=default_component_user \
+    DEPLOY_DEV_TOOLS=false \
+    INIT_CONFIG=default_init_config \
+    TRUSTED_PLUGIN=default_trusted_plugin_path \
+    THING_POLICY_NAME=default_thing_policy_name
+RUN env
+
+# Entrypoint script to install and run Greengrass
+COPY "greengrass-entrypoint.sh" /
+
+# Install Greengrass v2 dependencies
+RUN yum update -y && \
+    yum install -y tar unzip wget sudo procps which shadow-utils python3 java-11-amazon-corretto-headless && \
+    wget $GREENGRASS_RELEASE_URI && \
+    rm -rf /var/cache/yum && \
+    chmod +x /greengrass-entrypoint.sh && \
+    mkdir -p /opt/greengrassv2 $GGC_ROOT_PATH && unzip $GREENGRASS_ZIP_FILE -d /opt/greengrassv2 && rm $GREENGRASS_ZIP_FILE
+RUN dos2unix /greengrass-entrypoint.sh
+
+# modify /etc/sudoers
+COPY "modify-sudoers.sh" /
+RUN chmod +x /modify-sudoers.sh
+RUN dos2unix /modify-sudoers.sh
+RUN ./modify-sudoers.sh
+
+ENTRYPOINT ["/greengrass-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ This guide will show you how to:
 * Mac OSX or Linux host computer running Docker and Docker Compose (optional).  
  * The Docker installation (version 18.09 or later) can be found [here](https://docs.docker.com/install/ ).
  * The Docker Compose installation (version 1.22 or later) can be found [here]( https://docs.docker.com/compose/install/).
-   Docker for Mac OS and Docker Toolbox include Compose, so those platforms don't need a separate Compose installation. Note: You must have version 1.22 or later because `init` support is required.  
+   Docker for Mac OS and Docker Toolbox include Compose, so those platforms don't need a separate Compose installation. Note: You must have version 1.22 or later because `init` support is required.
+* Windows OS
+ * Use the `Dockerfile4WindowsBuild` as your build image `-f` parameter
   
 ## Running AWS IoT Greengrass in a Docker Container  
 The following steps show how to build the Docker image from the Dockerfile and configure AWS IoT Greengrass to run in a Docker container.  

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ This guide will show you how to:
   
 ## Prerequisites  
 * Mac OSX or Linux host computer running Docker and Docker Compose (optional).  
- * The Docker installation (version 18.09 or later) can be found [here](https://docs.docker.com/install/ ).
- * The Docker Compose installation (version 1.22 or later) can be found [here]( https://docs.docker.com/compose/install/).
-   Docker for Mac OS and Docker Toolbox include Compose, so those platforms don't need a separate Compose installation. Note: You must have version 1.22 or later because `init` support is required.
+	* The Docker installation (version 18.09 or later) can be found [here](https://docs.docker.com/install/ ).
+	* The Docker Compose installation (version 1.22 or later) can be found [here]( https://docs.docker.com/compose/install/).
+	* Docker for Mac OS and Docker Toolbox include Compose, so those platforms don't need a separate Compose installation. Note: You must have version 1.22 or later because `init` support is required.
 * Windows OS
- * Use the `Dockerfile4WindowsBuild` as your build image `-f` parameter
+	* Use the `Dockerfile4WindowsBuild` as your build image `-f` parameter
   
 ## Running AWS IoT Greengrass in a Docker Container  
 The following steps show how to build the Docker image from the Dockerfile and configure AWS IoT Greengrass to run in a Docker container.  


### PR DESCRIPTION
**Issue #, N/A:**

**Description of changes:**
Added a new Dockerfile to allow for Image Builds from a Windows OS host (Windows 10 and Window 2022)

**Why is this change necessary:**
When I tried using the `Dockerfile` (as-is), I kept getting errors, in Windows OS.  

**How was this change tested:**
I was able to build images on a Windows OS (both Windows 10 and Windows Server 2022).  Greengrass devices ran as Docker container without any issues. 

**Any additional information or context required to review the change:**
Maybe there is a better way to resolve this. If there is, feel free to abandon/reject this PR.

**Checklist:**
- [x] Updated the README if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
